### PR TITLE
INTERNAL: Handle SaslClient on AuthThread

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,6 +118,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>com.bolyartech.scram_sasl</groupId>
+            <artifactId>scram_sasl</artifactId>
+            <version>2.0.2</version>
+        </dependency>
 
         <!-- TEST -->
         <dependency>

--- a/src/main/java/net/spy/memcached/auth/ScramMechanism.java
+++ b/src/main/java/net/spy/memcached/auth/ScramMechanism.java
@@ -1,0 +1,49 @@
+package net.spy.memcached.auth;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+public enum ScramMechanism {
+  SCRAM_SHA_256("SHA-256", "HmacSHA256");
+
+  private static final Map<String, ScramMechanism> MECHANISMS_MAP;
+
+  private final String mechanismName;
+  private final String hashAlgorithm;
+  private final String macAlgorithm;
+
+  static {
+    Map<String, ScramMechanism> map = new HashMap<>();
+    for (ScramMechanism mech : values()) {
+      map.put(mech.mechanismName, mech);
+    }
+    MECHANISMS_MAP = Collections.unmodifiableMap(map);
+  }
+
+  private ScramMechanism(String hashAlgorithm, String macAlgorithm) {
+    this.mechanismName = "SCRAM-" + hashAlgorithm;
+    this.hashAlgorithm = hashAlgorithm;
+    this.macAlgorithm = macAlgorithm;
+  }
+
+  public final String mechanismName() {
+    return this.mechanismName;
+  }
+  public String hashAlgorithm() {
+    return hashAlgorithm;
+  }
+  
+  public String macAlgorithm() {
+    return macAlgorithm;
+  }
+
+  public static ScramMechanism forMechanismName(String mechanismName) {
+    return MECHANISMS_MAP.get(mechanismName);
+  }
+
+  public static Collection<String> mechanismNames() {
+    return MECHANISMS_MAP.keySet();
+  }
+}

--- a/src/main/java/net/spy/memcached/auth/ScramSaslClient.java
+++ b/src/main/java/net/spy/memcached/auth/ScramSaslClient.java
@@ -1,0 +1,179 @@
+package net.spy.memcached.auth;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Map;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.NameCallback;
+import javax.security.auth.callback.PasswordCallback;
+import javax.security.sasl.SaslClient;
+import javax.security.sasl.SaslClientFactory;
+import javax.security.sasl.SaslException;
+
+import com.bolyartech.scram_sasl.client.ScramClientFunctionality;
+import com.bolyartech.scram_sasl.client.ScramClientFunctionalityImpl;
+import com.bolyartech.scram_sasl.common.ScramException;
+
+public class ScramSaslClient implements SaslClient {
+
+  enum State {
+    SEND_CLIENT_FIRST_MESSAGE,
+    RECEIVE_SERVER_FIRST_MESSAGE,
+    RECEIVE_SERVER_FINAL_MESSAGE,
+    COMPLETE,
+    FAILED
+  }
+
+  private final ScramMechanism mechanism;
+  private final CallbackHandler callbackHandler;
+  private final ScramClientFunctionality scf;
+  private State state;
+
+  public ScramSaslClient(ScramMechanism mechanism, CallbackHandler cbh) {
+    this.callbackHandler = cbh;
+    this.mechanism = mechanism;
+    this.scf = new ScramClientFunctionalityImpl(
+            mechanism.hashAlgorithm(), mechanism.macAlgorithm());
+    this.state = State.SEND_CLIENT_FIRST_MESSAGE;
+  }
+
+  @Override
+  public String getMechanismName() {
+    return this.mechanism.mechanismName();
+  }
+
+  @Override
+  public boolean hasInitialResponse() {
+    return true;
+  }
+
+  @Override
+  public byte[] evaluateChallenge(byte[] challenge) throws SaslException {
+    try {
+      switch (this.state) {
+        case SEND_CLIENT_FIRST_MESSAGE:
+          if (challenge != null && challenge.length != 0) {
+            throw new SaslException("Expected empty challenge");
+          }
+
+          NameCallback nameCallback = new NameCallback("Name: ");
+
+          try {
+            callbackHandler.handle(new Callback[]{nameCallback});
+          } catch (Throwable e) {
+            throw new SaslException("User name could not be obtained", e);
+          }
+
+          String username = nameCallback.getName();
+          byte[] clientFirstMessage = this.scf.prepareFirstMessage(username).getBytes();
+          this.state = State.RECEIVE_SERVER_FIRST_MESSAGE;
+          return clientFirstMessage;
+        
+        case RECEIVE_SERVER_FIRST_MESSAGE:
+          String serverFirstMessage = new String(challenge, StandardCharsets.UTF_8);
+
+          PasswordCallback passwordCallback = new PasswordCallback("Password: ", false);
+          try {
+            callbackHandler.handle(new Callback[]{passwordCallback});
+          } catch (Throwable e) {
+            throw new SaslException("Password could not be obtained", e);
+          }
+
+          String password = String.valueOf(passwordCallback.getPassword());
+          byte[] clientFinalMessage = this.scf.prepareFinalMessage(
+                  password, serverFirstMessage).getBytes();
+          if (clientFinalMessage == null) {
+            throw new SaslException("clientFinalMessage should not be null");
+          }
+          this.state = State.RECEIVE_SERVER_FINAL_MESSAGE;
+          return clientFinalMessage;
+        
+        case RECEIVE_SERVER_FINAL_MESSAGE:
+          String serverFinalMessage = new String(challenge, StandardCharsets.UTF_8);
+          if (!this.scf.checkServerFinalMessage(serverFinalMessage)) {
+            throw new SaslException("Sasl authentication using " + this.mechanism +
+                    " failed with error: invalid server final message");
+          }
+          this.state = State.COMPLETE;
+          return new byte[]{};
+      
+        default:
+          throw new SaslException("Unexpected challenge in Sasl client state " + this.state);
+      }
+    } catch (ScramException e) {
+      this.state = State.FAILED;
+      throw new SaslException("ScramException", e);
+    } catch (SaslException e) {
+      this.state = State.FAILED;
+      throw e;
+    }
+  }
+
+  @Override
+  public boolean isComplete() {
+    return this.state == State.COMPLETE;
+  }
+
+  @Override
+  public byte[] unwrap(byte[] incoming, int offset, int len) throws SaslException {
+    if (!isComplete()) {
+      throw new IllegalStateException("Authentication exchange has not completed");
+    }
+    return Arrays.copyOfRange(incoming, offset, offset + len);
+  }
+
+  @Override
+  public byte[] wrap(byte[] outgoing, int offset, int len) throws SaslException {
+    if (!isComplete()) {
+      throw new IllegalStateException("Authentication exchange has not completed");
+    }
+    return Arrays.copyOfRange(outgoing, offset, offset + len);
+  }
+
+  @Override
+  public Object getNegotiatedProperty(String propName) {
+    if (!isComplete()) {
+      throw new IllegalStateException("Authentication exchange has not completed");
+    }
+    return null;
+  }
+
+  @Override
+  public void dispose() throws SaslException {
+  }
+
+  public static class ScramSaslClientFactory implements SaslClientFactory {
+    @Override
+    public SaslClient createSaslClient(String[] mechanisms,
+            String authorizationId,
+            String protocol,
+            String serverName,
+            Map<String, ?> props,
+            CallbackHandler cbh) throws SaslException {
+
+      ScramMechanism mechanism = null;
+      for (String mech : mechanisms) {
+        mechanism = ScramMechanism.forMechanismName(mech);
+        if (mechanism != null) {
+          break;
+        }
+      }
+      if (mechanism == null) {
+        throw new SaslException(String.format("Requested mechanisms '%s' not supported."
+                + " Supported mechanisms are '%s'.",
+                Arrays.asList(mechanisms), ScramMechanism.mechanismNames()));
+      }
+
+      return new ScramSaslClient(mechanism, cbh);
+    }
+
+    @Override
+    public String[] getMechanismNames(Map<String, ?> props) {
+      Collection<String> mechanisms = ScramMechanism.mechanismNames();
+      return mechanisms.toArray(new String[0]);
+    }
+  }
+}

--- a/src/main/java/net/spy/memcached/auth/ScramSaslClientProvider.java
+++ b/src/main/java/net/spy/memcached/auth/ScramSaslClientProvider.java
@@ -1,0 +1,21 @@
+package net.spy.memcached.auth;
+
+import java.security.Provider;
+import java.security.Security;
+
+import net.spy.memcached.auth.ScramSaslClient.ScramSaslClientFactory;
+
+public final class ScramSaslClientProvider extends Provider {
+
+  private static final long serialVersionUID = 1L;
+
+  @SuppressWarnings("deprecation")
+  private ScramSaslClientProvider() {
+    super("SASL/SCRAM Client Provider", 1.0, "SASL/SCRAM Client Provider for Arcus");
+    put("SaslClientFactory.SCRAM-SHA-256", ScramSaslClientFactory.class.getName());
+  }
+
+  public static void initialize() {
+    Security.addProvider(new ScramSaslClientProvider());
+  }
+}

--- a/src/main/java/net/spy/memcached/protocol/ascii/AsciiOperationFactory.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/AsciiOperationFactory.java
@@ -147,11 +147,11 @@ public class AsciiOperationFactory extends BaseOperationFactory {
   }
 
   public SASLStepOperation saslStep(SaslClient sc, byte[] challenge, OperationCallback cb) {
-    throw new UnsupportedOperationException();
+    return new SASLAuthOperationImpl(sc, challenge, cb);
   }
 
   public SASLAuthOperation saslAuth(SaslClient sc, OperationCallback cb) {
-    throw new UnsupportedOperationException();
+    return new SASLAuthOperationImpl(sc, null, cb);
   }
 
   public SetAttrOperation setAttr(String key, Attributes attrs,

--- a/src/main/java/net/spy/memcached/protocol/ascii/SASLAuthOperationImpl.java
+++ b/src/main/java/net/spy/memcached/protocol/ascii/SASLAuthOperationImpl.java
@@ -1,0 +1,132 @@
+package net.spy.memcached.protocol.ascii;
+
+import java.nio.Buffer;
+import java.nio.ByteBuffer;
+
+import javax.security.sasl.SaslClient;
+
+import net.spy.memcached.ops.OperationCallback;
+import net.spy.memcached.ops.OperationState;
+import net.spy.memcached.ops.OperationStatus;
+import net.spy.memcached.ops.OperationType;
+import net.spy.memcached.ops.SASLAuthOperation;
+import net.spy.memcached.ops.SASLStepOperation;
+import net.spy.memcached.ops.StatusCode;
+
+public class SASLAuthOperationImpl extends OperationImpl
+        implements SASLAuthOperation, SASLStepOperation {
+
+  private byte[] data = null;
+  private int readOffset = 0;
+  private byte lookingFor = '\0';
+
+  protected final byte[] challenge;
+  protected final SaslClient sc;
+
+  public SASLAuthOperationImpl(SaslClient sc, byte[] ch,
+                               OperationCallback cb) {
+    super(cb);
+    challenge = ch;
+    this.sc = sc;
+    setOperationType(OperationType.READ);
+  }
+
+  @Override
+  public final void handleLine(String line) {
+    if (line.equals("END")) {
+      String msg = "";
+      if (data != null) {
+        msg = new String(data);
+      }
+      getCallback().receivedStatus(new OperationStatus(true,
+              msg, StatusCode.SUCCESS));
+      transitionState(OperationState.COMPLETE);
+      data = null;
+    } else if (line.startsWith("VALUE ")) {
+      String[] stuff = line.split(" ");
+      data = new byte[Integer.parseInt(stuff[3])];
+      readOffset = 0;
+      setReadType(OperationReadType.DATA);
+    }
+  }
+
+  @Override
+  public final void handleRead(ByteBuffer bb) {
+    if (lookingFor == '\0') {
+      int toRead = data.length - readOffset;
+      int available = bb.remaining();
+      toRead = Math.min(toRead, available);
+      bb.get(data, readOffset, toRead);
+      readOffset += toRead;
+    }
+
+    if (readOffset == data.length && lookingFor == '\0') {
+      lookingFor = '\r';
+    }
+
+    if (lookingFor != '\0' && bb.hasRemaining()) {
+      do {
+        byte tmp = bb.get();
+        switch (lookingFor) {
+          case '\r':
+            lookingFor = '\n';
+            break;
+          case '\n':
+            lookingFor = '\0';
+            break;
+        }
+      } while (lookingFor != '\0' && bb.hasRemaining());
+
+      if (lookingFor == '\0') {
+        readOffset = 0;
+        setReadType(OperationReadType.LINE);
+      }
+    }
+  }
+
+  @Override
+  public void initialize() {
+    StringBuilder commandBuilder = new StringBuilder();
+
+    byte[] clientData = null;
+    try {
+      clientData = sc.evaluateChallenge(challenge);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+
+    commandBuilder.append("sasl auth");
+    if (challenge == null) {
+      commandBuilder.append(' ');
+      commandBuilder.append(sc.getMechanismName());
+    }
+    commandBuilder.append(' ');
+    commandBuilder.append(clientData.length);
+    commandBuilder.append("\r\n");
+    commandBuilder.append(new String(clientData));
+    commandBuilder.append("\r\n");
+
+    String commandStr = commandBuilder.toString();
+    byte[] commandLine = commandStr.getBytes();
+    int size = commandLine.length;
+    ByteBuffer bb = ByteBuffer.allocate(size);
+    bb.put(commandLine);
+    ((Buffer) bb).flip();
+    setBuffer(bb);
+  }
+
+  @Override
+  public boolean isBulkOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isPipeOperation() {
+    return false;
+  }
+
+  @Override
+  public boolean isIdempotentOperation() {
+    return false;
+  }
+}

--- a/src/test/java/net/spy/memcached/Namsic.java
+++ b/src/test/java/net/spy/memcached/Namsic.java
@@ -1,0 +1,60 @@
+package net.spy.memcached;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import net.spy.memcached.ConnectionFactoryBuilder.Protocol;
+import net.spy.memcached.auth.AuthDescriptor;
+import net.spy.memcached.auth.PlainCallbackHandler;
+import net.spy.memcached.auth.ScramSaslClientProvider;
+
+public class Namsic {
+  private static final String[] mechanism = {"SCRAM-SHA-256"};
+  private static final String username = "plainuser";
+  private static final String password = "plainpw";
+
+  private ArcusClient newClient(boolean useCluster, boolean useBinaryProtocol) throws IOException {
+    ConnectionFactoryBuilder cfb = new ConnectionFactoryBuilder()
+        .setAuthDescriptor(new AuthDescriptor(mechanism, 
+        new PlainCallbackHandler(username, password)));
+    
+    if (useBinaryProtocol) {
+      cfb.setProtocol(Protocol.BINARY);
+    }
+
+    if (useCluster) {
+      return ArcusClient.createArcusClient("ncp-2c4-001:40000", "sample", cfb);
+    } else {
+      return new ArcusClient(cfb.build(), AddrUtil.getAddresses("127.0.0.1:40010"));
+    }
+
+  }
+
+  // mvn test -Dtest=Namsic#testSasl
+  @Test
+  public void testSasl() throws Exception {
+    ScramSaslClientProvider.initialize();
+
+    ArcusClient mc = newClient(true, true);
+    Thread.sleep(10000);
+
+    assertTrue(mc.set("namsic:kv01", 30, "value01").get());
+    assertEquals("value01", mc.get("namsic:kv01"));
+  }
+  
+  // mvn test -Dtest=Namsic#testAsciiSasl
+  @Test
+  public void testAsciiSasl() throws Exception {
+    ScramSaslClientProvider.initialize();
+
+    ArcusClient mc = newClient(true, false);
+
+    Thread.sleep(10000);
+    assertTrue(mc.set("namsic:kv01", 30, "value01").get());
+    assertEquals("value01", mc.get("namsic:kv01"));
+  }
+}


### PR DESCRIPTION
### 🔗 Related Issue
- jam2in/arcus-works#672

### ⌨️ What I did
- SaslClient 객체를 AuthThread에서 생성하여 인자로 넘기도록 변경
- multi-step auth mechanism 사용 시, 매 step 마다 SaslClient 객체를 생성하는 대신,
하나의 클라이언트를 사용하여 인증 과정의 context를 보존